### PR TITLE
Show a nicer error when the Region is omitted.

### DIFF
--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -135,6 +135,9 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPort = flags.Int("rackspace-ssh-port")
 	d.EnableDockerInstall = flags.String("rackspace-docker-install") == "true"
 
+	if d.Region == "" {
+		return missingEnvOrOption("Region", "OS_REGION_NAME", "--rackspace-region")
+	}
 	if d.Username == "" {
 		return missingEnvOrOption("Username", "OS_USERNAME", "--rackspace-username")
 	}


### PR DESCRIPTION
This PR shows a better error message if you omit the required `--rackspace-region` CLI option.

```
FATA[0000] Region must be specified either using the environment variable OS_REGION_NAME or the CLI option --rackspace-region 
```

Part of the changes requested in docker/machine#73.