### PR TITLE
Improve server creation

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -59,6 +59,11 @@ func (c *GenericClient) CreateInstance(d *Driver) (string, error) {
 			},
 		}
 	}
+
+	log.WithFields(log.Fields{
+		"Name": d.MachineName,
+	}).Info("Creating server...")
+
 	server, err := servers.Create(c.Compute, keypairs.CreateOptsExt{
 		serverOpts,
 		d.KeyPairName,

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -709,12 +709,18 @@ func (d *Driver) installDocker() error {
 		`echo "export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376\"" >> /etc/default/docker`,
 		`service docker start`,
 	}); err != nil {
-		log.Error("Docker installation failed")
+		log.Error("The docker installation failed.")
 		log.Error(
-			"The driver assume your instance is running Ubuntu. If this is not the case, you should use the ",
-			"option --openstack-docker-install=false when creating the machine and then install manually",
+			"The driver assumes that your instance is running Ubuntu. If this is not the case, you should ",
+			"use the option --openstack-docker-install=false (or --{provider}-docker-install=false) when ",
+			"creating a machine, and then install and configure docker manually.",
 		)
-		return err
+		log.Error(
+			`Also, you can use "machine ssh" to manually configure docker on this host.`,
+		)
+
+		// Don't return this ssh error so that host creation succeeds and "machine ssh" and "machine rm"
+		// are usable.
 	}
 	return nil
 }

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -711,7 +711,7 @@ func (d *Driver) installDocker() error {
 	}); err != nil {
 		log.Error("Docker installation failed")
 		log.Error(
-			"The driver assume your instance is running Ubuntu. If this is no the case, you should use the ",
+			"The driver assume your instance is running Ubuntu. If this is not the case, you should use the ",
 			"option --openstack-docker-install=false when creating the machine and then install manually",
 		)
 		return err

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -703,7 +703,7 @@ func (d *Driver) installDocker() error {
 
 	if err := d.sshExec([]string{
 		`apt-get install -y curl`,
-		`curl -sSL https://get.docker.com | /bin/sh`,
+		`curl -sSL https://get.docker.com | /bin/sh >/var/log/docker-install.log 2>&1`,
 		`service docker stop`,
 		`curl -sSL https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity -o /usr/bin/docker`,
 		`echo "export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376\"" >> /etc/default/docker`,


### PR DESCRIPTION
This PR has a few tweaks to server creation, as requested in docker/machine#73.
1. It logs a message before issuing the server creation call, to let you know that the driver is doing something when you run `machine create` without debug output on.
2. Output from the script at https://get.docker.com is redirected into `/var/log/docker-install.log` instead of ending up on stderr (or stdout).
3. Errors during docker installation and configuration won't prevent the host from being fully created. This lets you use `machine ssh` to log in and correct the docker installation manually, for example, or `machine rm` to get rid of the host.
